### PR TITLE
レシピに材料を付けて投稿

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -4,11 +4,11 @@ class FoodsController < ApplicationController
   end
 
   def new
-    @form = FoodTagForm.new
+    @form = FoodForm.new
   end
 
   def create
-    @form = FoodTagForm.new(food_params)
+    @form = FoodForm.new(food_params)
     if @form.save
       redirect_to foods_path, success: t('.success')
     else
@@ -20,6 +20,6 @@ class FoodsController < ApplicationController
   private
 
   def food_params
-    params.require(:food_tag_form).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }, ingredients_attributes: %i[ingredient_name quantity proper_quantity]).merge(user_id: current_user.id)
+    params.require(:food_form).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }, ingredients_attributes: %i[ingredient_name quantity proper_quantity]).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -20,6 +20,6 @@ class FoodsController < ApplicationController
   private
 
   def food_params
-    params.require(:food_tag_form).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }).merge(user_id: current_user.id)
+    params.require(:food_tag_form).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }, ingredients_attributes: %i[ingredient_name quantity proper_quantity]).merge(user_id: current_user.id)
   end
 end

--- a/app/form/food_form.rb
+++ b/app/form/food_form.rb
@@ -1,7 +1,7 @@
-class FoodTagForm
+class FoodForm
   include ActiveModel::Model
 
-  DEFAULT_INGREDIENT_COUNT = 5
+  DEFAULT_INGREDIENT_COUNT = 3
 
   attr_accessor :name, :image, :recipe, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, :user_id, :food_tags, :food_id, :tag_id, :ingredients, :ingredient_name, :quantity, :proper_quantity
 

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -8,6 +8,8 @@ class Food < ApplicationRecord
   has_many :food_tags, dependent: :destroy
   # tagとはfood_tagsを介してつながる
   has_many :tags, through: :food_tags
+  # foodはingredientsとの関係を複数持ち、foodが削除されればそのfoodのidを持つレコードも削除
+  has_many :ingredients, dependent: :destroy
 
   with_options presence: true do
     validates :name

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,0 +1,16 @@
+class Ingredient < ApplicationRecord
+  belongs_to :food
+
+  validates :name, presence: true
+
+  validate :quantity_or_proper_quantity_check
+
+  private
+
+  # quantityとproper_quantityのどちらか入力した場合しか許可しない
+  def quantity_or_proper_quantity_check
+    return if (quantity.present?) ^ (proper_quantity == true)
+
+    errors.add(:quantity, 'は分量を入力するか適量用のチェックボックスを選択するかどちらか片方にしてください')
+  end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,7 +1,7 @@
 class Ingredient < ApplicationRecord
   belongs_to :food
 
-  validates :name, presence: true
+  validates :ingredient_name, presence: true
 
   validate :quantity_or_proper_quantity_check
 

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -1,5 +1,6 @@
 <div class="flex justify-center items-center py-10">
 	<div class="lg:w-2/5 md:w-1/2 w-11/12">
+  <% # binding.pry %>
 		<%= form_with model: @form, url: foods_path, local: true, class: "bg-white p-5 lg:p-10 rounded-lg shadow-lg min-w-full" do |f| %>
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>
@@ -35,6 +36,25 @@
       	<%= f.label :tag, class: "text-gray-800 font-semibold block my-3 text-md" %>
 			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, include_hidden: false, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
           <%= b.label(class: "bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-2 px-2") { b.check_box(class: "hidden") + b.text } %>
+        <% end %>
+      </div>
+      <div>
+        <%= f.label '材料', class: "text-gray-800 font-semibold block my-3 text-md" %>
+        <%= f.fields_for :ingredients do |i| %>
+        <div class="grid grid-cols-4 gap-4">
+          <div class="col-span-2">
+            <%= f.label '材料名', class: "text-gray-800 font-semibold block my-3 text-sm" %>
+            <%= i.text_field :name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+          </div>
+          <div>
+            <%= f.label '分量', class: "text-gray-800 font-semibold block my-3 text-sm" %>
+            <%= i.text_field :quantity, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+          </div>
+          <div class="text-center">
+            <%= f.label '適量', class: "text-gray-800 font-semibold block my-3 text-sm" %>
+            <%= i.check_box :proper_quantity, {}, true, false %>
+          </div>
+        </div>
         <% end %>
       </div>
       <%= f.submit class: "w-full mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -1,6 +1,5 @@
 <div class="flex justify-center items-center py-10">
 	<div class="lg:w-2/5 md:w-1/2 w-11/12">
-  <% # binding.pry %>
 		<%= form_with model: @form, url: foods_path, local: true, class: "bg-white p-5 lg:p-10 rounded-lg shadow-lg min-w-full" do |f| %>
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>
@@ -39,19 +38,19 @@
         <% end %>
       </div>
       <div>
-        <%= f.label '材料', class: "text-gray-800 font-semibold block my-3 text-md" %>
+        <%= f.label :ingredient, class: "text-gray-800 font-semibold block my-3 text-md" %>
         <%= f.fields_for :ingredients do |i| %>
         <div class="grid grid-cols-4 gap-4">
           <div class="col-span-2">
-            <%= f.label '材料名', class: "text-gray-800 font-semibold block my-3 text-sm" %>
-            <%= i.text_field :name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+            <%= f.label :ingredient_name, class: "text-gray-800 font-semibold block my-3 text-sm" %>
+            <%= i.text_field :ingredient_name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
           </div>
           <div>
-            <%= f.label '分量', class: "text-gray-800 font-semibold block my-3 text-sm" %>
+            <%= f.label :quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
             <%= i.text_field :quantity, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
           </div>
           <div class="text-center">
-            <%= f.label '適量', class: "text-gray-800 font-semibold block my-3 text-sm" %>
+            <%= f.label :proper_quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
             <%= i.check_box :proper_quantity, {}, true, false %>
           </div>
         </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -2,7 +2,7 @@
   <div class="bg-danger-50 border-l-4 border-danger-500 text-danger-700 p-4" role="alert">
     <ul>
       <% object.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li>・<%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,4 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+require 'carrierwave/orm/activerecord'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -27,7 +27,7 @@ ja:
         proper_quantity: 適量
   activemodel:
     attributes:
-      food_tag_form:
+      food_form:
         name: レシピ名
         recipe: 作り方
         image: 料理写真

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,9 +1,10 @@
 ja:
   activerecord:
     models:
-      users: ユーザー
-      foods: レシピ
-      tags: タグ
+      user: ユーザー
+      food: レシピ
+      tag: タグ
+      ingredient: 材料
     attributes:
       user:
         name: 名前
@@ -18,6 +19,12 @@ ja:
         cooking_time: 調理時間
         cooking_time_unit: 調理時間の単位
         serving: 何人前
+      tag:
+        name: タグ
+      ingredient:
+        ingredient_name: 材料名
+        quantity: 材料の量
+        proper_quantity: 適量
   activemodel:
     attributes:
       food_tag_form:
@@ -29,6 +36,10 @@ ja:
         cooking_time_unit: 調理時間の単位
         serving: 何人前
         tag: タグ
+        ingredient: 材料
+        ingredient_name: 材料名
+        quantity: 材料の量
+        proper_quantity: 適量
   enums:
     food:
       cooking_time_unit:

--- a/db/migrate/20220110110833_create_ingredients.rb
+++ b/db/migrate/20220110110833_create_ingredients.rb
@@ -1,0 +1,12 @@
+class CreateIngredients < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ingredients do |t|
+      t.references :food, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :quantity
+      t.boolean :proper_quantity, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220117010408_rename_name_column_to_ingredients.rb
+++ b/db/migrate/20220117010408_rename_name_column_to_ingredients.rb
@@ -1,0 +1,5 @@
+class RenameNameColumnToIngredients < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :ingredients, :name, :ingredient_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_04_093427) do
+ActiveRecord::Schema.define(version: 2022_01_10_110833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,16 @@ ActiveRecord::Schema.define(version: 2022_01_04_093427) do
     t.index ["user_id"], name: "index_foods_on_user_id"
   end
 
+  create_table "ingredients", force: :cascade do |t|
+    t.bigint "food_id", null: false
+    t.string "name", null: false
+    t.string "quantity"
+    t.boolean "proper_quantity", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["food_id"], name: "index_ingredients_on_food_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -61,4 +71,5 @@ ActiveRecord::Schema.define(version: 2022_01_04_093427) do
   add_foreign_key "food_tags", "foods"
   add_foreign_key "food_tags", "tags"
   add_foreign_key "foods", "users"
+  add_foreign_key "ingredients", "foods"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_10_110833) do
+ActiveRecord::Schema.define(version: 2022_01_17_010408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2022_01_10_110833) do
 
   create_table "ingredients", force: :cascade do |t|
     t.bigint "food_id", null: false
-    t.string "name", null: false
+    t.string "ingredient_name", null: false
     t.string "quantity"
     t.boolean "proper_quantity", default: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## 概要
c576b0e1cfd48dc5259cc1108a2e6cc3905adaf8 `ingredients`テーブルを作成しました。
7e4a907dfd9fec62fdacef973afbd311c76cb879 `food`モデルにアソシエーションの設定をしました。
6c03e286e1f7a103a2c0814bdf5d2007b7d468cb 材料入力フォームを追加しレイアウトを少し整えました。
0e240c355d433306410a61d4e808c594e8b79ed6 カラム名を変更しました。
2b6c4855d5a324632575989caa3fec9c456ea528 材料に関する日本語訳を追加しました。
ad95c7c0178705fe6f80610977b70852e931bcc9 材料の投稿機能を実装しました。
44070d82634e734f3f1aea08371900a30344a8b9 フォームオブジェクトのファイル名とクラス名と変更しました。

材料入力フォーム
<img width="1429" alt="スクリーンショット 2022-01-17 12 02 58" src="https://user-images.githubusercontent.com/74707158/149701906-ba2c82a0-9734-49c0-8496-750cf925ebe6.png">

エラーメッセージ
<img width="1434" alt="スクリーンショット 2022-01-17 12 03 10" src="https://user-images.githubusercontent.com/74707158/149701910-18d18ecb-3a2f-40d7-b27d-77b11aaedf5e.png">

ログ
![スクリーンショット 2022-01-17 12 04 11](https://user-images.githubusercontent.com/74707158/149701916-3aedafd6-b861-42e9-9801-a3d4c5a2367b.png)

## 確認方法
1. テーブルを作成したので、`rails db:migrate`を実行してください
2. `/foods/new`にアクセスして、レシピと材料のフォームを入力し投稿し成功することを確認してください
3. また、材料のフォームが未入力の場合は上記のようなエラーが表示されることを確認してください

## 影響範囲
- テーブルが追加されDBの構成が変わりました。
- レシピを投稿する際に材料も投稿することが必須となりました。

## チェックリスト
- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした

## コメント
一旦、材料の数を３つに固定して実装しました。
現状として、材料を３つ全て入力しないと投稿ができない状態になっています。
今後やること
- 材料の数（フォームの数）を動的にする
- 材料の数に関わらず投稿できるようにする

考えていること
- `is_valid`のようなカラムを追加し、`true`のパラメータのみ保存処理を実行する
- gemの`cocoon`などを使ってフォームの数を動的にする
