### PR TITLE
レシピの編集・削除機能実装

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -38,6 +38,13 @@ class FoodsController < ApplicationController
     end
   end
 
+  def destroy
+    binding.pry
+    food = Food.find_by(uuid: params[:uuid])
+    food.destroy!
+    redirect_to foods_path
+  end
+
   private
 
   def food_params

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,4 +1,6 @@
 class FoodsController < ApplicationController
+  before_action :get_food, only: %i[edit update destroy]
+
   def index
     @foods = Food.all.includes(:user, :tags).order(created_at: :desc)
   end
@@ -24,30 +26,31 @@ class FoodsController < ApplicationController
   end
 
   def edit
-    @food = Food.find_by(uuid: params[:uuid])
     @form = FoodForm.new(food: @food)
   end
 
   def update
-    @food = Food.find_by(uuid: params[:uuid])
     @form = FoodForm.new(food_params, food: @food)
     if @form.update
-      redirect_to food_path(@food.uuid)
+      redirect_to food_path(@food.uuid), success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :edit
     end
   end
 
   def destroy
-    binding.pry
-    food = Food.find_by(uuid: params[:uuid])
-    food.destroy!
-    redirect_to foods_path
+    @food.destroy!
+    redirect_to foods_path, success: t('.success')
   end
 
   private
 
   def food_params
     params.require(:food).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }, ingredients: %i[ingredient_name quantity proper_quantity]).merge(user_id: current_user.id)
+  end
+
+  def get_food
+    @food = current_user.foods.find_by(uuid: params[:uuid])
   end
 end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -23,9 +23,24 @@ class FoodsController < ApplicationController
     end
   end
 
+  def edit
+    @food = Food.find_by(uuid: params[:uuid])
+    @form = FoodForm.new(food: @food)
+  end
+
+  def update
+    @food = Food.find_by(uuid: params[:uuid])
+    @form = FoodForm.new(food_params, food: @food)
+    if @form.update
+      redirect_to food_path(@food.uuid)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def food_params
-    params.require(:food_form).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }, ingredients_attributes: %i[ingredient_name quantity proper_quantity]).merge(user_id: current_user.id)
+    params.require(:food).permit(:name, :recipe, :image, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, { food_tags: [] }, ingredients: %i[ingredient_name quantity proper_quantity]).merge(user_id: current_user.id)
   end
 end

--- a/app/form/food_form.rb
+++ b/app/form/food_form.rb
@@ -2,17 +2,16 @@ class FoodForm
   include ActiveModel::Model
   require 'google/cloud/translate'
 
-  DEFAULT_INGREDIENT_COUNT = 3
-
-  attr_accessor :name, :image, :recipe, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, :user_id, :food_tags, :food_id, :tag_id, :ingredients, :ingredient_name, :quantity, :proper_quantity
+  attr_accessor :food, :name, :image, :recipe, :cooking_comment, :cooking_time, :cooking_time_unit, :serving, :user_id, :food_tags, :food_id, :tag_id, :ingredients, :ingredient_name, :quantity, :proper_quantity
 
   validate :food_validate
   validate :ingredient_validate
 
-  def initialize(attributes = nil, food: Food.new, food_tag: FoodTag.new)
+  delegate :persisted?, to: :@food
+
+  def initialize(attributes = nil, food: Food.new)
     @food = food
-    @food_tag = food_tag
-    self.ingredients = DEFAULT_INGREDIENT_COUNT.times.map { Ingredient.new } unless ingredients.present?
+    attributes ||= default_attributes
     super(attributes)
   end
 
@@ -26,14 +25,10 @@ class FoodForm
     return false if invalid?
 
     ActiveRecord::Base.transaction do
-      food = Food.new(food_params)
-      food.save!
+      food = Food.create!(food_params)
 
-      if food_tags.present?
-        food_tags.each do |food_tag|
-          food.food_tags.create!(tag_id: food_tag)
-        end
-      end
+      # タグのidを渡す
+      food.tag_ids = food_tags
 
       # 翻訳する値を格納する配列
       @translate_array = []
@@ -58,7 +53,59 @@ class FoodForm
     false
   end
 
+  def update
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      food.update!(food_params)
+
+      # タグのidを渡す
+      food.tag_ids = food_tags
+
+      # 翻訳する値を格納する配列
+      @translate_array = []
+
+      # レシピの材料を全て削除して再度データを作り直す
+      food.ingredients.destroy_all
+      ingredients.each do |ingredient|
+        food_ingredient = food.ingredients.create!(ingredient_params(ingredient))
+        # 翻訳に使う値を取り出して格納
+        @translate_array.push(food_ingredient[:quantity], food_ingredient[:ingredient_name])
+      end
+
+      # 翻訳する処理を実行
+      translated_ingredients = google_translation(@translate_array)
+      # 翻訳したデータを使ってマクロ栄養素を算出
+      nutrition_data = nutrition_calculate(translated_ingredients)
+      # 投稿されたレシピのマクロ栄養素として保存
+      food.create_nutrition!(nutrition_data)
+
+      true
+    end
+  rescue StandardError => e
+    p e
+    false
+  end
+
+  def to_model
+    @food
+  end
+
   private
+
+  def default_attributes
+    {
+      name: @food.name,
+      image: @food.image,
+      recipe: @food.recipe,
+      cooking_comment: @food.cooking_comment,
+      cooking_time: @food.cooking_time,
+      cooking_time_unit: @food.cooking_time_unit,
+      serving: @food.serving,
+      food_tags: @food.tags,
+      ingredients: @food.ingredients
+    }
+  end
 
   def food_params
     {
@@ -75,9 +122,9 @@ class FoodForm
 
   def ingredient_params(ingredient)
     {
-      ingredient_name: ingredient.ingredient_name,
-      quantity: ingredient.quantity,
-      proper_quantity: ingredient.proper_quantity
+      ingredient_name: ingredient[:ingredient_name],
+      quantity: ingredient[:quantity],
+      proper_quantity: ingredient[:proper_quantity]
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,8 @@ class User < ApplicationRecord
 
   # ユーザー保存直前にuuidを生成
   before_create -> { self.uuid = SecureRandom.uuid }
+
+  def mine?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -16,12 +16,7 @@
       </p>
       <div>
         <% if current_user.mine?(food) %>
-          <%= link_to edit_food_path(food.uuid) do %>
-            <i class="fas fa-pencil-alt mr-2 text-green-700"></i>
-          <% end %>
-          <%= link_to food_path(food.uuid), method: :delete do %>
-            <i class="fas fa-trash-alt mr-2 text-red-700"></i>
-          <% end %>
+          <%= render 'update_destroy', food: food  %>
         <% end %>
       </div>
   </div>

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -16,7 +16,10 @@
       </p>
       <div>
         <%= link_to edit_food_path(food.uuid) do %>
-          <i class="fas fa-edit mr-2"></i>
+          <i class="fas fa-pencil-alt mr-2 text-green-700"></i>
+        <% end %>
+        <%= link_to food_path(food.uuid), method: :delete do %>
+          <i class="fas fa-trash-alt mr-2 text-red-700"></i>
         <% end %>
       </div>
   </div>

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -15,11 +15,13 @@
         <i class="fas fa-user-alt"></i><%= link_to food.user.name, user_path(food.user.uuid) %>
       </p>
       <div>
-        <%= link_to edit_food_path(food.uuid) do %>
-          <i class="fas fa-pencil-alt mr-2 text-green-700"></i>
-        <% end %>
-        <%= link_to food_path(food.uuid), method: :delete do %>
-          <i class="fas fa-trash-alt mr-2 text-red-700"></i>
+        <% if current_user.mine?(food) %>
+          <%= link_to edit_food_path(food.uuid) do %>
+            <i class="fas fa-pencil-alt mr-2 text-green-700"></i>
+          <% end %>
+          <%= link_to food_path(food.uuid), method: :delete do %>
+            <i class="fas fa-trash-alt mr-2 text-red-700"></i>
+          <% end %>
         <% end %>
       </div>
   </div>

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-white max-w-sm rounded overflow-hidden shadow-lg">
-  <div class= "w-full m-3">
-    <%= image_tag food.image_url(:thumb), class: "w-11/12 shadow-lg" %>
+  <div class= "w-full my-3">
+    <%= image_tag food.image_url(:thumb), class: "w-11/12 shadow-lg mx-auto" %>
   </div>
   <div class="px-6 pb-4">
     <div class="font-bold text-xl mb-2">

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -10,9 +10,16 @@
       <%= food.cooking_comment %>
     </p>
   </div>
-  <p class="text-gray-700 text-base px-5 pb-2 underline">
-    <i class="fas fa-user-alt"></i><%= link_to food.user.name, user_path(food.user.uuid) %>
-  </p>
+  <div class="flex justify-between">
+      <p class="text-gray-700 text-base px-5 pb-2 underline">
+        <i class="fas fa-user-alt"></i><%= link_to food.user.name, user_path(food.user.uuid) %>
+      </p>
+      <div>
+        <%= link_to edit_food_path(food.uuid) do %>
+          <i class="fas fa-edit mr-2"></i>
+        <% end %>
+      </div>
+  </div>
   <div class="px-6 pb-2">
     <% food.tags.each do |tag| %>
       <span class="inline-block bg-orange-400 rounded-full px-3 py-1 text-sm font-semibold text-white mr-2 mb-2"><%= tag.name %></span>

--- a/app/views/foods/_ingredients_form.html.erb
+++ b/app/views/foods/_ingredients_form.html.erb
@@ -1,5 +1,5 @@
 <div class="js-medium-form border border-orange-400 rounded-xl p-4 mb-3">
-  <%= f.fields_for :ingredients, Ingredient.new, {} do |i| %>
+  <%= f.fields_for 'ingredients[]', Ingredient.new, {} do |i| %>
     <div class="grid grid-cols-6 gap-4">
       <div class="col-span-3">
         <%= i.label :ingredient_name,class: "text-gray-800 font-semibold block my-3 text-sm" %>

--- a/app/views/foods/_ingredients_form.html.erb
+++ b/app/views/foods/_ingredients_form.html.erb
@@ -1,0 +1,23 @@
+<div class="js-medium-form border border-orange-400 rounded-xl p-4 mb-3">
+  <%= f.fields_for :ingredients, Ingredient.new, {} do |i| %>
+    <div class="grid grid-cols-6 gap-4">
+      <div class="col-span-3">
+        <%= i.label :ingredient_name,class: "text-gray-800 font-semibold block my-3 text-sm" %>
+        <%= i.text_field :ingredient_name, value: ingredient.ingredient_name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+      </div>
+      <div>
+        <%= i.label :quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
+        <%= i.text_field :quantity, value: ingredient.quantity, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+      </div>
+      <div class="text-center">
+        <%= i.label :proper_quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
+        <%= i.check_box :proper_quantity, {cheched: ingredient.proper_quantity.is_a?(TrueClass)}, true, false  %>
+      </div>
+      <div class="mt-5">
+        <div class='my-3' onclick='removeMediumForm(event)'>
+          <p class="text-center cursor-pointer text-white bg-gradient-to-r from-red-400 via-red-500 to-red-600 hover:bg-gradient-to-br focus:ring-4 focus:ring-red-300 dark:focus:ring-red-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mt-6">削除</p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/foods/_ingredients_form.html.erb
+++ b/app/views/foods/_ingredients_form.html.erb
@@ -3,15 +3,15 @@
     <div class="grid grid-cols-6 gap-4">
       <div class="col-span-3">
         <%= i.label :ingredient_name,class: "text-gray-800 font-semibold block my-3 text-sm" %>
-        <%= i.text_field :ingredient_name, value: ingredient.ingredient_name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+        <%= i.text_field :ingredient_name, value: ingredient[:ingredient_name], class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
         <%= i.label :quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
-        <%= i.text_field :quantity, value: ingredient.quantity, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
+        <%= i.text_field :quantity, value: ingredient[:quantity], class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div class="text-center">
         <%= i.label :proper_quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
-        <%= i.check_box :proper_quantity, {cheched: ingredient.proper_quantity.is_a?(TrueClass)}, true, false  %>
+        <%= i.check_box :proper_quantity, {cheched: ingredient[:proper_quantity].is_a?(TrueClass)}, true, false  %>
       </div>
       <div class="mt-5">
         <div class='my-3' onclick='removeMediumForm(event)'>

--- a/app/views/foods/_ingredients_form.html.erb
+++ b/app/views/foods/_ingredients_form.html.erb
@@ -1,4 +1,4 @@
-<div class="js-medium-form border border-orange-400 rounded-xl p-4 mb-3">
+<div class="js-remove-ingredient-form border border-orange-400 rounded-xl p-4 mb-3">
   <%= f.fields_for 'ingredients[]', Ingredient.new, {} do |i| %>
     <div class="grid grid-cols-6 gap-4">
       <div class="col-span-3">
@@ -11,7 +11,7 @@
       </div>
       <div class="text-center">
         <%= i.label :proper_quantity, class: "text-gray-800 font-semibold block my-3 text-sm" %>
-        <%= i.check_box :proper_quantity, {cheched: ingredient[:proper_quantity].is_a?(TrueClass)}, true, false  %>
+        <%= i.check_box :proper_quantity, {checked: ingredient[:proper_quantity], class:"w-1/3 h-1/3 mt-1"}, true, false  %>
       </div>
       <div class="mt-5">
         <div class='my-3' onclick='removeMediumForm(event)'>

--- a/app/views/foods/_update_destroy.html.erb
+++ b/app/views/foods/_update_destroy.html.erb
@@ -1,6 +1,6 @@
 <%= link_to edit_food_path(food.uuid) do %>
   <i class="fas fa-pencil-alt mr-2 text-green-700"></i>
 <% end %>
-<%= link_to food_path(food.uuid), method: :delete do %>
+<%= link_to food_path(food.uuid), method: :delete, data: { confirm: 'このレシピを削除してよろしいですか？' } do %>
   <i class="fas fa-trash-alt mr-2 text-red-700"></i>
 <% end %>

--- a/app/views/foods/_update_destroy.html.erb
+++ b/app/views/foods/_update_destroy.html.erb
@@ -1,0 +1,6 @@
+<%= link_to edit_food_path(food.uuid) do %>
+  <i class="fas fa-pencil-alt mr-2 text-green-700"></i>
+<% end %>
+<%= link_to food_path(food.uuid), method: :delete do %>
+  <i class="fas fa-trash-alt mr-2 text-red-700"></i>
+<% end %>

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -4,11 +4,11 @@
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>
       <div>
-      	<%= f.label :name, class: "text-gray-800 font-semibold block my-3 text-md" %>
+        <%= f.label :name, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_field :name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :recipe, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :recipe, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_area :recipe, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
@@ -20,46 +20,46 @@
 			  <%= f.text_area :cooking_comment, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :cooking_time, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :cooking_time, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_field :cooking_time, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :cooking_time_unit, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :cooking_time_unit, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
         <%= f.select :cooking_time_unit, Food.cooking_time_units.keys.map {|k| [I18n.t("enums.food.cooking_time_unit.#{k}"), k]}, { include_blank: "選択してください" },class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :serving, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :serving, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_field :serving, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
       	<%= f.label 'タグ', class: "text-gray-800 font-semibold block my-3 text-md" %>
-			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, { checked: @food.tag_ids.map(&:to_param) }, class: "hidden w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
+			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, { checked: @food.tag_ids.map(&:to_param) }, class: "bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
           <%= b.label(class: "bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-2 px-2 active:bg-red-600") { b.check_box + b.text } %>
         <% end %>
       </div>
       <div>
-        <%= f.label '材料', class: "text-gray-800 font-semibold block my-3 text-md" %>
-        <div id='js-media-form'>
+        <%= f.label '材料', class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
+        <div id='js-add-ingredient-form'>
           <% @form.ingredients.each do |ingredient| %>
             <%= render 'ingredients_form', f: f, ingredient: ingredient %>
           <% end %>
         </div>
-        <div class='my-2'>
-          <span class='cursor-pointer underline hover:opacity-75' onclick='addMediumForm(event)'>材料追加</span>
+        <div class='my-2 pt-2'>
+          <span class='cursor-pointer text-white bg-gradient-to-r from-yellow-400 via-orange-400 to-orange-600 hover:bg-gradient-to-br focus:ring-4 focus:ring-pink-300 dark:focus:ring-pink-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2' onclick='addMediumForm(event)'>材料追加</span>
         </div>
       </div>
-      <div>
-        <%= f.submit class: "w-full mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
+      <div class="text-center">
+        <%= f.submit class: "w-1/4 mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
       </div>
 
       <script type="text/javascript">
         const addMediumForm = (e) => {
-          const mediaForm = document.getElementById('js-media-form')
+          const mediaForm = document.getElementById('js-add-ingredient-form')
           mediaForm.insertAdjacentHTML('afterend', "<%= j(render 'ingredients_form', {f: f, ingredient: Ingredient.new}) %>");
         }
 
         const removeMediumForm = (e) => {
-          const mediumForm = e.currentTarget.closest('.js-medium-form')
+          const mediumForm = e.currentTarget.closest('.js-remove-ingredient-form')
           mediumForm.remove();
         }
       </script>

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="flex justify-center items-center py-10">
 	<div class="lg:w-2/5 md:w-1/2 w-11/12">
-		<%= form_with model: @form, local: true, class: "bg-white p-5 lg:p-10 rounded-lg shadow-lg min-w-full" do |f| %>
+		<%= form_with model: @form, url: food_path(@food.uuid), local: true, class: "bg-white p-5 lg:p-10 rounded-lg shadow-lg min-w-full" do |f| %>
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>
       <div>
@@ -33,8 +33,8 @@
       </div>
       <div>
       	<%= f.label 'タグ', class: "text-gray-800 font-semibold block my-3 text-md" %>
-			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, include_hidden: false, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
-          <%= b.label(class: "bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-2 px-2") { b.check_box(class: "hidden") + b.text } %>
+			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, { checked: @food.tag_ids.map(&:to_param) }, class: "hidden w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
+          <%= b.label(class: "bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-2 px-2 active:bg-red-600") { b.check_box + b.text } %>
         <% end %>
       </div>
       <div>

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center items-center py-10">
-	<div class="lg:w-2/5 md:w-1/2 w-11/12">
+	<div class="lg:w-4/5 md:w-1/2 w-11/12">
 		<%= form_with model: @form, url: food_path(@food.uuid), local: true, class: "bg-white p-5 lg:p-10 rounded-lg shadow-lg min-w-full" do |f| %>
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -40,8 +40,10 @@
       <div>
         <%= f.label '材料', class: "text-gray-800 font-semibold block my-3 text-md" %>
         <div id='js-media-form'>
-          <% @form.ingredients.each do |ingredient| %>
-            <%= render 'ingredients_form', f: f, ingredient: ingredient %>
+          <% if @form.ingredients.present? %>
+            <% @form.ingredients.each do |ingredient| %>
+              <%= render 'ingredients_form', f: f, ingredient: ingredient %>
+            <% end %>
           <% end %>
         </div>
         <div class='my-2'>

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -4,11 +4,11 @@
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>
       <div>
-      	<%= f.label :name, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :name, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_field :name, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :recipe, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :recipe, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_area :recipe, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
@@ -20,48 +20,48 @@
 			  <%= f.text_area :cooking_comment, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :cooking_time, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :cooking_time, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_field :cooking_time, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :cooking_time_unit, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :cooking_time_unit, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
         <%= f.select :cooking_time_unit, Food.cooking_time_units.keys.map {|k| [I18n.t("enums.food.cooking_time_unit.#{k}"), k]}, { include_blank: "選択してください" },class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
-      	<%= f.label :serving, class: "text-gray-800 font-semibold block my-3 text-md" %>
+      	<%= f.label :serving, class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
 			  <%= f.text_field :serving, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" %>
       </div>
       <div>
       	<%= f.label 'タグ', class: "text-gray-800 font-semibold block my-3 text-md" %>
-			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, include_hidden: false, class: "w-full bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
-          <%= b.label(class: "bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-2 px-2") { b.check_box(class: "hidden") + b.text } %>
+			  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, include_hidden: false, class: "bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
+          <%= b.label(class: "bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-2 px-2") { b.check_box + b.text } %>
         <% end %>
       </div>
       <div>
-        <%= f.label '材料', class: "text-gray-800 font-semibold block my-3 text-md" %>
-        <div id='js-media-form'>
+        <%= f.label '材料', class: "text-gray-800 font-semibold block mt-3 text-md" %><p class="text-sm text-red-500">※必須</p>
+        <div id='js-add-ingredient-form'>
           <% if @form.ingredients.present? %>
             <% @form.ingredients.each do |ingredient| %>
               <%= render 'ingredients_form', f: f, ingredient: ingredient %>
             <% end %>
           <% end %>
         </div>
-        <div class='my-2'>
-          <span class='cursor-pointer underline hover:opacity-75' onclick='addMediumForm(event)'>材料追加</span>
+        <div class='my-2 pt-2'>
+          <span class='cursor-pointer text-white bg-gradient-to-r from-yellow-400 via-orange-400 to-orange-600 hover:bg-gradient-to-br focus:ring-4 focus:ring-pink-300 dark:focus:ring-pink-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2' onclick='addMediumForm(event)'>材料追加</span>
         </div>
       </div>
-      <div>
-        <%= f.submit class: "w-full mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
+      <div class="text-center">
+        <%= f.submit class: "w-1/4 mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
       </div>
 
       <script type="text/javascript">
         const addMediumForm = (e) => {
-          const mediaForm = document.getElementById('js-media-form')
+          const mediaForm = document.getElementById('js-add-ingredient-form')
           mediaForm.insertAdjacentHTML('afterend', "<%= j(render 'ingredients_form', {f: f, ingredient: Ingredient.new}) %>");
         }
 
         const removeMediumForm = (e) => {
-          const mediumForm = e.currentTarget.closest('.js-medium-form')
+          const mediumForm = e.currentTarget.closest('.js-remove-ingredient-form')
           mediumForm.remove();
         }
       </script>

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center items-center py-10">
-	<div class="lg:w-2/5 md:w-1/2 w-11/12">
+	<div class="lg:w-4/5 md:w-1/2 w-11/12">
 		<%= form_with model: @form, local: true, class: "bg-white p-5 lg:p-10 rounded-lg shadow-lg min-w-full" do |f| %>
 			<h1 class="text-center text-2xl mb-6 text-gray-600 font-bold font-sans"><%= t('.title') %></h1>
       <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -5,12 +5,17 @@
       <h1 class="text-5xl text-center py-3 font-bold"><%= @food.name %></h1>
       <div class="pl-10 pr-3 mt-6 mx-auto grid grid-cols-2 gap-x-8">
         <div>
-          <div class="">
+          <div>
             <%= image_tag @food.image_url(:show), class: "w-full shadow-lg rounded-xl relative z-1 bg-orange-50 p-3" %>
           </div>
           <div class="p-5">
             <p class="text-xl"><i class="fas fa-user-edit"></i>投稿者</p>
             <%= link_to @food.user.name, user_path(@food.user.uuid), class: "text-3xl" %>
+          </div>
+          <div class="pl-5 text-2xl">
+            <% if current_user.mine?(@food) %>
+              <%= render 'update_destroy', food: @food  %>
+            <% end %>          
           </div>
         </div>
         <div class="flex flex-wrap" id="tabs-id">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -12,7 +12,6 @@
         </div>
 
         <div class="hidden md:flex flex-col md:flex-row md:ml-auto mt-3 md:mt-0" id="navbar-collapse">
-          <%= link_to "クイズ", "#", class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>
           <%= link_to "レシピ一覧", "#", class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>
           <%= link_to "ログイン", login_path, class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>
           <%= link_to "新規登録", new_user_path, class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-solid border-orange-100 bg-orange-400 rounded hover:bg-white hover:text-orange-700 transition-colors duration-300 mt-1 md:mt-0 md:ml-1" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,7 +12,6 @@
         </div>
 
         <div class="hidden md:flex flex-col md:flex-row md:ml-auto mt-3 md:mt-0" id="navbar-collapse">
-          <%= link_to "クイズ", "#", class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>
           <%= link_to "レシピ投稿", new_food_path, class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>
           <%= link_to "レシピ一覧", foods_path, class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>
           <%= link_to "ログアウト", logout_path, method: :delete, class: "p-2 lg:px-4 md:mx-2 text-orange-100 text-center border border-transparent rounded hover:bg-orange-100 hover:text-orange-700 transition-colors duration-300" %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -23,7 +23,7 @@ ja:
         name: タグ
       ingredient:
         ingredient_name: 材料名
-        quantity: 材料の量
+        quantity: 量
         proper_quantity: 適量
   activemodel:
     attributes:
@@ -38,7 +38,7 @@ ja:
         tag: タグ
         ingredient: 材料
         ingredient_name: 材料名
-        quantity: 材料の量
+        quantity: 量
         proper_quantity: 適量
   enums:
     food:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -27,3 +27,10 @@ ja:
     create:
       success: レシピを投稿しました。
       fail: レシピの投稿に失敗しました。
+    edit:
+      title: レシピ編集
+    update:
+      success: レシピを更新しました。
+      fail: レシピの更新に失敗しました。
+    destroy:
+      success: レシピを削除しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete '/logout', to: 'user_sessions#destroy'
 
   resources :users, param: :uuid, only: %i[new show create]
-  resources :foods, param: :uuid, only: %i[index show new create]
+  resources :foods, param: :uuid, only: %i[index show new create edit update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete '/logout', to: 'user_sessions#destroy'
 
   resources :users, param: :uuid, only: %i[new show create]
-  resources :foods, param: :uuid, only: %i[index show new create edit update]
+  resources :foods, param: :uuid, only: %i[index show new create edit update destroy]
 end


### PR DESCRIPTION
## 概要
218a394bb260aff4e58c78bb9a3edaf48c9743bb レシピ新規投稿・編集ページで材料のフォームの数を動的にしました。
98adc43f79c2ba0466684bf78fe4d0d4ed04d590 レシピの編集機能を実装しました。
b305d18e1269b493a2a60365c3860ab6a292f260 レシピの編集機能の部分を少しリファクタリングしました。
0c7eb76db6c6291d9aadf10dba70e37a4b2d0d4f ヘッダーの`クイズ`のリンクを削除しました。
7b9f82566632a8ee42d41f50a30eb23ca16a97a5 レシピの削除機能を実装しました。
c5f6c61621ac07c78ea0ad8e21f020c947492243 レシピが自分のものか判別して自分の場合だけ編集・削除ボタンが表示されるようにしました。

レシピの材料入力フォーム
[![Image from Gyazo](https://i.gyazo.com/7c8799e72015a8189a9c200499ccf38c.gif)](https://gyazo.com/7c8799e72015a8189a9c200499ccf38c)

レシピ一覧画面（編集・削除ボタン）
<img width="906" alt="スクリーンショット 2022-02-02 12 02 40" src="https://user-images.githubusercontent.com/74707158/152086893-0efcd6f3-c888-4cba-bfca-a312f2f45f45.png">

## 確認方法
1. レシピ新規投稿ページ`/foods/new`にアクセスし、材料入力フォームの追加と削除ができることを確認してください。
2. レシピ編集ページ`/foods/:uuid/edit`にアクセスし、レシピ内容・タグ・材料を編集してリダイレクト先の詳細ページで内容が更新されていることを確認してください。
3. レシピ一覧ページ`/foods`の削除ボタンをクリックするとそのレシピが削除されることを確認してください。
4. レシピ一覧ページで自分の投稿にのみ編集・削除ボタンが表示されていることを確認してください。

## 影響範囲
レシピを投稿する際に材料の数が動的になりました。

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
**レシピの材料の編集について**
本来なら、材料のデータを取得してそのレコードを更新するのが一般的だと思いますがその方法は取りませんでした。
材料の編集をする際に、一度そのレシピの材料を全て削除してから送られてきたパラメータで材料を作成することで編集したように見せかけています。
例として、レシピ新規投稿時に、`材料A`、`材料B`、`材料C`で投稿したとしてその後に編集で`材料C`を削除するとなった場合を考えます。
編集フォームでその材料のところの削除ボタンを押してもフォームが消えるだけで、レコードが消えるわけではないです。
これを実現する方法として、一度`材料A`、`材料B`、`材料C`のデータを全て削除して、送られてきた`材料A`、`材料B`のパラメータで再度データを作成することで`材料C`だけを削除したように見せかけています。
この方法はあまり好ましくない気がするので修正したいと思います。