### PR TITLE
decoratorを使って量の表示を適量に対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data'
 
 # ユーザー認証
 gem 'sorcery'
@@ -89,3 +89,6 @@ gem 'google-cloud-translate'
 # グラフ
 gem 'chart-js-rails'
 gem 'gon'
+
+# デコレータ
+gem 'draper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.4.1)
       activesupport (= 6.1.4.1)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.1.4.1)
       activemodel (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -104,6 +108,13 @@ GEM
     diff-lcs (1.4.4)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
@@ -606,6 +617,8 @@ GEM
     trailblazer-option (0.1.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2021.5)
+      tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (2.1.0)
     web-console (4.2.0)
@@ -643,6 +656,7 @@ DEPENDENCIES
   carrierwave (~> 2.0)
   carrierwave-i18n
   chart-js-rails
+  draper
   enum_help
   factory_bot_rails
   gon

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,0 +1,8 @@
+class ApplicationDecorator < Draper::Decorator
+  # Define methods for all decorated objects.
+  # Helpers are accessed through `helpers` (aka `h`). For example:
+  #
+  #   def percent_amount
+  #     h.number_to_percentage object.amount, precision: 2
+  #   end
+end

--- a/app/decorators/ingredient_decorator.rb
+++ b/app/decorators/ingredient_decorator.rb
@@ -1,0 +1,13 @@
+class IngredientDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/ingredient_decorator.rb
+++ b/app/decorators/ingredient_decorator.rb
@@ -1,13 +1,7 @@
 class IngredientDecorator < Draper::Decorator
   delegate_all
 
-  # Define presentation-specific methods here. Helpers are accessed through
-  # `helpers` (aka `h`). You can override attributes, for example:
-  #
-  #   def created_at
-  #     helpers.content_tag :span, class: 'time' do
-  #       object.created_at.strftime("%a %m/%d/%y")
-  #     end
-  #   end
-
+  def proper_quantity?
+    quantity.present? ? quantity : '適量'
+  end
 end

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -61,7 +61,7 @@
                 <div class="p-2">
                   <ul class="list-disc list-inside">
                     <% @food.ingredients.each do |ingredient| %>
-                      <li><%= ingredient.ingredient_name %> : <%= ingredient.quantity %></li>
+                      <li><%= ingredient.ingredient_name %> : <%= ingredient.decorate.proper_quantity? %></li>
                     <% end %>
                   </ul>
                 </div>


### PR DESCRIPTION
## 概要
a568d9ad048ec24e5144eaa453ef554f67e1d0bc `decorator`を使うためにgem`draper`を導入しました。
b0e5d96bbdaf6c414c99289f512f6aa09df3b144 `decorator`を使ってレシピの詳細ページで材料の量の表示に対応しました。

レシピ詳細ページ
![スクリーンショット 2022-02-04 19 16 57](https://user-images.githubusercontent.com/74707158/152518717-13a02edb-926a-4172-8ddf-16fda9b3224a.png)

## 確認方法
1. Gem を追加したので `bundle install` を実行してください
2. レシピ新規作成ページ`/foods/new`にアクセスし、具体的な量を持つ材料と適量の材料、両方の材料を持つレシピを作成してください。
3. そのレシピの詳細ページ`/foods/:uuid`にアクセスし、材料の箇所で具体的な量を入力した材料の量にはその値が、適量にチェックを入れた材料の量には`適量`と表示されていることを確認してください。

## 影響範囲
特になし

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
特になし
