### PR TITLE
MVPリリース後の軽微な修正

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -8,8 +8,8 @@ class FoodsController < ApplicationController
 
   def show
     @food = Food.find_by(uuid: params[:uuid])
-    gon.nutrition = @food.nutrition
-    gon.nutrition_calories = @food.nutrition.calorie_calculates
+    gon.nutrition = @food.nutrition.nutrition_calculates(@food.serving)
+    gon.nutrition_calories = @food.nutrition.calorie_calculates(@food.serving)
   end
 
   def new

--- a/app/models/nutrition.rb
+++ b/app/models/nutrition.rb
@@ -9,10 +9,23 @@ class Nutrition < ApplicationRecord
     validates :fat
   end
 
-  def calorie_calculates
-    macro_calories = [carbo * 4, protein * 4, fat * 9]
+  def calorie_calculates(serving)
+    macro_calories = [
+      carbo * 4 / serving,
+      protein * 4 / serving,
+      fat * 9 / serving
+    ]
+    self.calories /= serving
     results = []
     macro_calories.each { |calorie| results << (calorie / calories * 100).round(1) }
     results << calories.to_i
+  end
+
+  def nutrition_calculates(serving)
+    [
+      self.carbo /= serving,
+      self.protein /= serving,
+      self.fat /= serving
+    ]
   end
 end

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -52,7 +52,7 @@
         </div>
       </div>
       <div class="text-center">
-        <%= f.submit class: "w-1/2 lg:w-1/4 mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
+        <%= f.submit class: "cursor-pointer w-1/2 lg:w-1/4 mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
       </div>
 
       <script type="text/javascript">

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -54,7 +54,7 @@
         </div>
       </div>
       <div class="text-center">
-        <%= f.submit class: "w-1/2 lg:w-1/4 mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
+        <%= f.submit class: "cursor-pointer w-1/2 lg:w-1/4 mt-6 bg-orange-400 rounded-lg px-4 py-2 text-lg text-white tracking-wide font-semibold font-sans" %>
       </div>
 
       <script type="text/javascript">

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -67,8 +67,11 @@
                 </div>
               </div>
               <!-- 調理時間 -->
-              <div>
-
+              <div class="p-3">
+                <h1 class="text-2xl font-bold underline"><%= Food.human_attribute_name(:cooking_time) %></h1>
+                <div class="p-2">
+                  <%= @food.cooking_time %><%= @food.cooking_time_unit_i18n %>
+                </div>
               </div>
               <!-- コメント -->
               <div class="p-3">

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -57,14 +57,18 @@
             <div>
               <!--材料 -->
               <div class="p-3">
-                <h1 class="text-2xl font-bold underline"><%= Ingredient.model_name.human %></h1>
+                <h1 class="text-2xl font-bold underline"><%= Ingredient.model_name.human %>（<%= @food.serving %>人前）</h1>
                 <div class="p-2">
                   <ul class="list-disc list-inside">
                     <% @food.ingredients.each do |ingredient| %>
-                      <li><%= ingredient.ingredient_name %> : <%= ingredient.decorate.proper_quantity? %></li>
+                      <li><span class="font-semibold"><%= ingredient.ingredient_name %></span> : <%= ingredient.decorate.proper_quantity? %></li>
                     <% end %>
                   </ul>
                 </div>
+              </div>
+              <!-- 調理時間 -->
+              <div>
+
               </div>
               <!-- コメント -->
               <div class="p-3">

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -121,9 +121,9 @@
     datasets: [
       {
         data: [
-          gon.nutrition.carbo,
-          gon.nutrition.protein,
-          gon.nutrition.fat
+          gon.nutrition[0],
+          gon.nutrition[1],
+          gon.nutrition[2]
         ],
         fill: true,
         backgroundColor: "rgba(255,204,0,0.2)",


### PR DESCRIPTION
## 概要
cd5502977096d96fe9e59577ba23cdc4fdd18025 レシピ投稿・編集ページの送信ボタンのホバー時にカーソルがポインターになるように修正しました。
869ae84b22da8739ee45aba570d225d0ef98bd5b レシピ詳細ページにそのレシピが何人前かを表示するようにしました。
37817903ed107caaa7705606ca2ac7170a2b05a9 レシピ詳細ページにそのレシピの調理時間を表示するようにしました。
d7bf5bc7d33a03d459c2cf5e537d53f3fbf38aa7 レシピ詳細ページのマクロ栄養素・カロリーを1食あたりの表示に切り替えました。

投稿・編集ページ
[![Image from Gyazo](https://i.gyazo.com/b60d1ee22636991c7f955613b7151b3f.gif)](https://gyazo.com/b60d1ee22636991c7f955613b7151b3f)

レシピ詳細ページ
何人前かの表示と調理時間の表示
<img width="1382" alt="スクリーンショット 2022-02-10 16 03 47" src="https://user-images.githubusercontent.com/74707158/153355065-fcbea2d0-32de-40e2-8a91-3539c73f059d.png">

マクロ栄養素
<img width="694" alt="スクリーンショット 2022-02-10 16 06 03" src="https://user-images.githubusercontent.com/74707158/153355404-be42426b-5037-4eeb-be53-9bd2bb339d2f.png">

カロリー
<img width="670" alt="スクリーンショット 2022-02-10 16 06 14" src="https://user-images.githubusercontent.com/74707158/153355420-ab5648ca-ac8b-474b-91ab-2935fab5afac.png">

## 確認方法
1. レシピ新規投稿ページ`/foods/new`とレシピ編集ページ`/foods/:uuid/edit`にアクセスして、送信ボタンにカーソルをホバーするとカーソルがポインターに変わることを確認してください。
2. レシピ詳細ページ`/foods/:uuid`にアクセスして、そのレシピの何人前と調理時間が表示されていることを確認してください。
3. また、レシピ詳細ページでマクロ栄養素とカロリーが１食あたりの表示になっていることを確認してください。

## 影響範囲
特になし

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
MVPリリースしてユーザーからフィードバックを元に簡単な修正を行いました。
