### PR TITLE
レシピの検索機能実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Layout/LineLength:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 30
+  Max: 100
 
 Metrics/BlockLength:
   Max: 30
@@ -44,6 +44,9 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   CountComments: false
   Max: 30
+
+Metrics/PerceivedComplexity:
+  Max: 20
 
 Naming/AccessorMethodName:
   Exclude:

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -59,6 +59,6 @@ class FoodsController < ApplicationController
 
   def search_params
     # 入力されてない場合を考慮してnilガード、入力されていればそのまま実行
-    params[:q]&.permit(:name, :ingredient_name, :not_ingredient_name, :over_calories, :under_calories, :over_carbo, :under_carbo, :over_protein, :under_protein, :over_fat, :under_fat)
+    params[:q]&.permit(:name, :ingredient_name, :not_ingredient_name, :over_calories, :under_calories, :over_carbo, :under_carbo, :over_protein, :under_protein, :over_fat, :under_fat, food_tags: [])
   end
 end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -3,7 +3,6 @@ class FoodsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    # @foods = Food.all.includes(:user, :tags).order(created_at: :desc)
     @food_search_form = FoodSearchForm.new(search_params)
     @foods = @food_search_form.search.includes(:user, :tags).order(created_at: :desc)
   end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -3,7 +3,9 @@ class FoodsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    @foods = Food.all.includes(:user, :tags).order(created_at: :desc)
+    # @foods = Food.all.includes(:user, :tags).order(created_at: :desc)
+    @food_search_form = FoodSearchForm.new(search_params)
+    @foods = @food_search_form.search.includes(:user, :tags).order(created_at: :desc)
   end
 
   def show
@@ -53,5 +55,10 @@ class FoodsController < ApplicationController
 
   def get_food
     @food = current_user.foods.find_by(uuid: params[:uuid])
+  end
+
+  def search_params
+    # 入力されてない場合を考慮してnilガード、入力されていればそのまま実行
+    params[:q]&.permit(:name)
   end
 end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -59,6 +59,6 @@ class FoodsController < ApplicationController
 
   def search_params
     # 入力されてない場合を考慮してnilガード、入力されていればそのまま実行
-    params[:q]&.permit(:name, :ingredient_name, :not_ingredient_name)
+    params[:q]&.permit(:name, :ingredient_name, :not_ingredient_name, :over_calories, :under_calories, :over_carbo, :under_carbo, :over_protein, :under_protein, :over_fat, :under_fat)
   end
 end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -59,6 +59,6 @@ class FoodsController < ApplicationController
 
   def search_params
     # 入力されてない場合を考慮してnilガード、入力されていればそのまま実行
-    params[:q]&.permit(:name)
+    params[:q]&.permit(:name, :ingredient_name, :not_ingredient_name)
   end
 end

--- a/app/form/food_search_form.rb
+++ b/app/form/food_search_form.rb
@@ -1,14 +1,12 @@
 class FoodSearchForm
   include ActiveModel::Model
-  include ActiveModel::Attributes
 
-  # attr_accessor :word
-  attribute :name, :string
+  attr_accessor :name
 
   def search
-    foods = Food.all
+    foods = Food.distinct.joins(:ingredients)
 
-    # レシピ名内で検索
-    foods.in_name(name)
+    # レシピ名と材料名から検索
+    foods.in_name(name).or(foods.in_ingredients(name))
   end
 end

--- a/app/form/food_search_form.rb
+++ b/app/form/food_search_form.rb
@@ -1,19 +1,44 @@
 class FoodSearchForm
   include ActiveModel::Model
 
-  attr_accessor :name, :ingredient_name, :not_ingredient_name, :food_tags
+  attr_accessor :name, :ingredient_name, :not_ingredient_name, :over_calories, :under_calories, :over_carbo, :under_carbo, :over_protein, :under_protein, :over_fat, :under_fat, :food_tags
 
   def search
     foods = Food.distinct.joins(:ingredients, :nutrition)
 
     # レシピ名と材料名から検索
-    foods = foods.in_name(name).or(foods.in_ingredients(name))
+    foods = foods.in_name(name).or(foods.in_ingredients(name)) if name.present?
 
     # 材料名のみで検索
-    foods = foods.in_ingredients(ingredient_name)
+    foods = foods.in_ingredients(ingredient_name) if ingredient_name.present?
 
     # 特定の材料を除外
-    foods.not_ingredients(not_ingredient_name) if not_ingredient_name.present?
+    foods = foods.not_ingredients(not_ingredient_name) if not_ingredient_name.present?
+
+    # カロリー検索（以上）
+    foods = foods.over_calories(over_calories) if over_calories.present?
+
+    # カロリー検索（以下）
+    foods = foods.under_calories(under_calories) if under_calories.present?
+
+    # 炭水化物検索（以上）
+    foods = foods.over_carbo(over_carbo) if over_carbo.present?
+
+    # 炭水化物検索（以下）
+    foods = foods.under_carbo(under_carbo) if under_carbo.present?
+
+    # たんぱく質検索（以上）
+    foods = foods.over_protein(over_protein) if over_protein.present?
+
+    # たんぱく質検索（以下）
+    foods = foods.under_protein(under_protein) if under_protein.present?
+
+    # 脂質検索（以上）
+    foods = foods.over_fat(over_fat) if over_fat.present?
+
+    # 脂質検索（以下）
+    foods = foods.under_fat(under_fat) if under_fat.present?
+
     foods
   end
 end

--- a/app/form/food_search_form.rb
+++ b/app/form/food_search_form.rb
@@ -1,0 +1,14 @@
+class FoodSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  # attr_accessor :word
+  attribute :name, :string
+
+  def search
+    foods = Food.all
+
+    # レシピ名内で検索
+    foods.in_name(name)
+  end
+end

--- a/app/form/food_search_form.rb
+++ b/app/form/food_search_form.rb
@@ -39,6 +39,15 @@ class FoodSearchForm
     # 脂質検索（以下）
     foods = foods.under_fat(under_fat) if under_fat.present?
 
+    # タグ検索
+    if food_tags.present?
+      food_tags.each do |tag|
+        food_ids = []
+        foods.each { |food| food_ids << food.id if food.tag_ids.include?(tag.to_i) }
+        foods = foods.where(id: food_ids)
+      end
+    end
+
     foods
   end
 end

--- a/app/form/food_search_form.rb
+++ b/app/form/food_search_form.rb
@@ -1,12 +1,19 @@
 class FoodSearchForm
   include ActiveModel::Model
 
-  attr_accessor :name
+  attr_accessor :name, :ingredient_name, :not_ingredient_name, :food_tags
 
   def search
-    foods = Food.distinct.joins(:ingredients)
+    foods = Food.distinct.joins(:ingredients, :nutrition)
 
     # レシピ名と材料名から検索
-    foods.in_name(name).or(foods.in_ingredients(name))
+    foods = foods.in_name(name).or(foods.in_ingredients(name))
+
+    # 材料名のみで検索
+    foods = foods.in_ingredients(ingredient_name)
+
+    # 特定の材料を除外
+    foods.not_ingredients(not_ingredient_name) if not_ingredient_name.present?
+    foods
   end
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -30,6 +30,9 @@ class Food < ApplicationRecord
   # 投稿の保存直前にuuidを生成
   before_create -> { self.uuid = SecureRandom.uuid }
 
-  # レシピ名に含まれているか
+  # レシピ名に限定
   scope :in_name, ->(name) { where('name LIKE ?', "%#{name}%") }
+  # 材料名に限定
+  # scope :in_ingredients, ->(name) { joins(:ingredients).where('ingredients.ingredient_name like ?', "%#{name}%") }
+  scope :in_ingredients, ->(name) { where('ingredients.ingredient_name like ?', "%#{name}%") }
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -36,4 +36,20 @@ class Food < ApplicationRecord
   scope :in_ingredients, ->(name) { where('ingredients.ingredient_name like ?', "%#{name}%") }
   # 特定の材料を含まない
   scope :not_ingredients, ->(not_ingredient_name) { where.not(id: Ingredient.distinct.where('ingredient_name like ?', "%#{not_ingredient_name}%").pluck(:food_id)) }
+  # カロリーで検索（以上）
+  scope :over_calories, ->(over_calories) { where('nutritions.calories >= ?', over_calories) }
+  # カロリーで検索（以下）
+  scope :under_calories, ->(under_calories) { where('nutritions.calories <= ?', under_calories) }
+  # 炭水化物で検索（以上）
+  scope :over_carbo, ->(over_carbo) { where('nutritions.carbo >= ?', over_carbo) }
+  # 炭水化物で検索（以下）
+  scope :under_carbo, ->(under_carbo) { where('nutritions.carbo <= ?', under_carbo) }
+  # たんぱく質で検索（以上）
+  scope :over_protein, ->(over_protein) { where('nutritions.protein >= ?', over_protein) }
+  # たんぱく質で検索（以下）
+  scope :under_protein, ->(under_protein) { where('nutritions.protein <= ?', under_protein) }
+  # 脂質で検索（以上）
+  scope :over_fat, ->(over_fat) { where('nutritions.fat >= ?', over_fat) }
+  # 脂質で検索（以下）
+  scope :under_fat, ->(under_fat) { where('nutritions.fat <= ?', under_fat) }
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -33,6 +33,7 @@ class Food < ApplicationRecord
   # レシピ名に限定
   scope :in_name, ->(name) { where('name LIKE ?', "%#{name}%") }
   # 材料名に限定
-  # scope :in_ingredients, ->(name) { joins(:ingredients).where('ingredients.ingredient_name like ?', "%#{name}%") }
   scope :in_ingredients, ->(name) { where('ingredients.ingredient_name like ?', "%#{name}%") }
+  # 特定の材料を含まない
+  scope :not_ingredients, ->(not_ingredient_name) { where.not(id: Ingredient.distinct.where('ingredient_name like ?', "%#{not_ingredient_name}%").pluck(:food_id)) }
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -29,4 +29,7 @@ class Food < ApplicationRecord
 
   # 投稿の保存直前にuuidを生成
   before_create -> { self.uuid = SecureRandom.uuid }
+
+  # レシピ名に含まれているか
+  scope :in_name, ->(name) { where('name LIKE ?', "%#{name}%") }
 end

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -1,6 +1,8 @@
 <div class="bg-white max-w-sm rounded overflow-hidden shadow-lg">
   <div class= "w-full my-3">
-    <%= image_tag food.image_url(:thumb), class: "w-11/12 shadow-lg mx-auto" %>
+    <%= link_to food_path(food.uuid) do %>
+      <%= image_tag food.image_url(:thumb), class: "w-11/12 shadow-lg mx-auto" %>
+    <% end %>
   </div>
   <div class="px-6 pb-4">
     <div class="font-bold text-xl mb-2">
@@ -19,7 +21,7 @@
   </div>
   <div class="px-6 pb-2 mt-2">
     <% food.tags.each do |tag| %>
-      <span class="inline-block bg-orange-400 rounded-full px-3 py-1 text-sm font-semibold text-white mr-2 mb-2"><%= tag.name %></span>
+      <%= link_to tag.name, foods_path(q: { food_tags: [tag.id] }), class: "inline-block bg-orange-400 rounded-full px-3 py-1 text-sm font-semibold text-white mr-2 mb-2" %>
     <% end %>
   </div>
 </div>

--- a/app/views/foods/_search.html.erb
+++ b/app/views/foods/_search.html.erb
@@ -2,7 +2,8 @@
   <div class="mx-auto w-1/3">
     <div class="flex justify-center py-1">
       <div class="flex h-8 mt-2">
-        <%= form_with model: @food_search_form, scope: :q, url: foods_path, method: :get, local: true do |f| %>
+        <% binding.pry %>
+        <%= form_with model: food_search_form, scope: :q, url: foods_path, method: :get, local: true do |f| %>
           <%= f.search_field :name, placeholder: 'キーワード', class: "px-4 bg-white border border-orange-500 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
           <%= f.button :type => "submit", class: "text-white bg-orange-500 px-5 rounded-lg border border-orange-500" do %>
             <i class="fas fa-search"></i>

--- a/app/views/foods/_search.html.erb
+++ b/app/views/foods/_search.html.erb
@@ -2,14 +2,144 @@
   <div class="mx-auto w-1/3">
     <div class="flex justify-center py-1">
       <div class="flex h-8 mt-2">
-        <% binding.pry %>
-        <%= form_with model: food_search_form, scope: :q, url: foods_path, method: :get, local: true do |f| %>
+        <%= form_with model: @food_search_form, scope: :q, url: foods_path, method: :get, local: true do |f| %>
           <%= f.search_field :name, placeholder: 'キーワード', class: "px-4 bg-white border border-orange-500 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
           <%= f.button :type => "submit", class: "text-white bg-orange-500 px-5 rounded-lg border border-orange-500" do %>
             <i class="fas fa-search"></i>
           <% end %>
+          <button class="text-gray-600 active:bg-orange-600 font-bold uppercase text-sm px-6 py-1 rounded underline hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('modal-id')">
+            詳細検索
+          </button>
         <% end %>
       </div>
     </div>
   </div>
 </div>
+
+<div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="modal-id">
+  <div class="relative w-auto my-6 mx-auto w-4/5 overflow-y-auto h-5/6">
+    <!--content-->
+    <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-yellow-50 outline-none focus:outline-none">
+      <!--header-->
+      <div class="flex justify-center p-5 rounded-t">
+        <h3 class="text-3xl font-semibold text-gray-600">
+          詳細検索
+        </h3>
+      </div>
+      <!--search body-->
+      <div>
+        <div class="relative lg:px-6">
+          <%= form_with model: @food_search_form, scope: :q, url: foods_path, method: :get, local: true do |f| %>
+            <div class="flex flex-col px-7 pt-2 border-t border-yellow-400">
+              <div class="grid grid-cols-1 lg:grid-cols-3">
+                <div>
+                  <div class="flex flex-col mb-3">
+                    <%= f.label 'フリーワード', class: "text-gray-600 font-semibold mb-2 underline" %>
+                    <%= f.search_field :name, placeholder: 'キーワード', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                  </div>
+                  <div class="flex flex-col mb-3">
+                    <%= f.label '材料', class: "text-gray-600 font-semibold mb-2 underline" %>
+                    <div class="flex mb-2">
+                      <%= f.search_field :ingredient_name, placeholder: '材料名', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                      <p class="pl-1">を含む</p>
+                    </div>
+                    <div class="flex">
+                      <%= f.search_field :not_ingredient_name, placeholder: '材料名', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                      <p class="pl-1">を含まない</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-span-2">
+                  <div class="flex flex-col">
+                    <%= f.label 'カロリー・マクロ栄養素', class: "text-gray-600 font-semibold mb-2 underline" %>
+                    <div class="flex flex-col mb-3">
+                      <div>
+                        <div class="grid grid-cols-1 lg:grid-cols-10">
+                          <%= f.label 'カロリー', class: "col-span-2 mr-2" %>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :over_calories, placeholder: '100', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">kcal以上</p>
+                          </div>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :under_calories, placeholder: '200', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">kcal以下</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <div class="grid grid-cols-1 lg:grid-cols-10">
+                          <%= f.label '炭水化物', class: "col-span-2 mr-2" %>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :over_carbo, placeholder: '0', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">g以上</p>
+                          </div>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :under_carbo, placeholder: '50', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">g以下</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <div class="grid grid-cols-1 lg:grid-cols-10">
+                          <%= f.label 'たんぱく質', class: "col-span-2 mr-2" %>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :over_protein, placeholder: '0', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">g以上</p>
+                          </div>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :under_protein, placeholder: '50', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">g以下</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <div class="grid grid-cols-1 lg:grid-cols-10">
+                          <%= f.label '脂質', class: "col-span-2 mr-2" %>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :over_fat, placeholder: '0', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">g以上</p>
+                          </div>
+                          <div class="flex mb-2 col-span-4">
+                            <%= f.search_field :under_fat, placeholder: '50', class: "w-1/2 px-4 bg-white border border-orange-400 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+                            <p class="pl-1">g以下</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="flex flex-col">
+                <%= f.label 'タグ', class: "text-gray-600 font-semibold underline" %>
+                <div class="flex flex-wrap gap-2 py-2">
+                  <%= f.collection_check_boxes :food_tags, Tag.all, :id, :name, include_hidden: false, class: "bg-gray-100 px-4 py-2 rounded-lg focus:outline-none" do |b| %>
+                    <%= b.label(class: "w-1/3 lg:w-1/6 bg-yellow-100 border-2 rounded-md border-orange-500 text-orange-500 mr-1 pl-1 mb-1 lg:mb-2") { b.check_box + b.text } %>
+                  <% end %>
+                </div>
+              </div>
+              <div class="flex justify-center border-t border-yellow-400 pt-2">
+                <%= f.submit '検索', class: "cursor-pointer w-1/2 lg:w-1/6 text-white text-lg bg-orange-500 px-3 rounded-lg border border-orange-500 my-2 py-1" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <!--footer-->
+      <div class="flex items-center justify-end pr-2 pb-2 rounded-b">
+        <button class="text-white bg-red-500 rounded-md font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('modal-id')">
+          ×閉じる
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="modal-id-backdrop"></div>
+
+<script type="text/javascript">
+  function toggleModal(modalID){
+    document.getElementById(modalID).classList.toggle("hidden");
+    document.getElementById(modalID + "-backdrop").classList.toggle("hidden");
+    document.getElementById(modalID).classList.toggle("flex");
+    document.getElementById(modalID + "-backdrop").classList.toggle("flex");
+  }
+</script>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -1,5 +1,5 @@
 <section>
-  <%= render 'shared/search' %>
+  <%= render 'search', food_search_form: @food_search_form %>
   <div class="container px-6 py-10 mx-auto">
     <h1 class="text-center text-3xl font-semibold text-gray-800 capitalize lg:text-4xl dark:text-white"><%= t('.title') %></h1>        
     <div class="grid grid-cols-1 gap-8 mt-8 xl:mt-12 xl:gap-12 md:grid-cols-2 xl:grid-cols-3">

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -1,8 +1,9 @@
 <section>
-    <div class="container px-6 py-10 mx-auto">
-        <h1 class="text-center text-3xl font-semibold text-gray-800 capitalize lg:text-4xl dark:text-white"><%= t('.title') %></h1>        
-        <div class="grid grid-cols-1 gap-8 mt-8 xl:mt-12 xl:gap-12 md:grid-cols-2 xl:grid-cols-3">
-          <%= render @foods %>
-        </div>
+  <%= render 'shared/search' %>
+  <div class="container px-6 py-10 mx-auto">
+    <h1 class="text-center text-3xl font-semibold text-gray-800 capitalize lg:text-4xl dark:text-white"><%= t('.title') %></h1>        
+    <div class="grid grid-cols-1 gap-8 mt-8 xl:mt-12 xl:gap-12 md:grid-cols-2 xl:grid-cols-3">
+    <%= render @foods %>
     </div>
+  </div>
 </section>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -1,8 +1,7 @@
 <section>
   <%= render 'search', food_search_form: @food_search_form %>
-  <div class="container px-6 py-10 mx-auto">
-    <h1 class="text-center text-3xl font-semibold text-gray-800 capitalize lg:text-4xl dark:text-white"><%= t('.title') %></h1>        
-    <div class="grid grid-cols-1 gap-8 mt-8 xl:mt-12 xl:gap-12 md:grid-cols-2 xl:grid-cols-3">
+  <div class="container px-6 py-10 mx-auto"> 
+    <div class="grid grid-cols-1 gap-8 xl:gap-12 md:grid-cols-2 xl:grid-cols-3">
     <%= render @foods %>
     </div>
   </div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,0 +1,14 @@
+<div class="bg-white shadow-md">
+  <div class="mx-auto w-1/3">
+    <div class="flex justify-center py-1">
+      <div class="flex h-8 mt-2">
+        <%= form_with model: @food_search_form, scope: :q, url: foods_path, method: :get, local: true do |f| %>
+          <%= f.search_field :name, placeholder: 'キーワード', class: "px-4 bg-white border border-orange-500 rounded-md sm:mx-2 dark:bg-orange-800 dark:text-orange-300 dark:border-orange-600 focus:border-orange-400 dark:focus:border-orange-300 focus:outline-none focus:ring focus:ring-orange-300 focus:ring-opacity-40" %>
+          <%= f.button :type => "submit", class: "text-white bg-orange-500 px-5 rounded-lg border border-orange-500" do %>
+            <i class="fas fa-search"></i>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
af4039b823b1a78c78086f05962c356abd2fc18a ヘッダーの下にフリーワードの検索フォームを追加しました。
d767ccb7b891672187103c4ff0537bf38df2ce54 f2c72dee089bcd1d97227af627b56000840f2186 レシピのタイトルと材料名から検索できるようにしました。
3745e93cb18c4f98fdf6c78515c13dc6f590c68b 詳細検索フォームを追加しました。
926a6e23667ecba4da5331c9dfe3f3bbcb2e8745 栄養素で検索できるようにしました。
bae4a047c2e8447e259be36d7f9653e28b5612bc タグの検索機能を実装しました。
3894dbc103bb93dc2bd83d163c9dee2dfae6a31d レシピ一覧ページの各投稿のタグからも検索できるようにしました。

フリーワード検索
[![Image from Gyazo](https://i.gyazo.com/182c6995669eda082c3ededb4e7fa230.gif)](https://gyazo.com/182c6995669eda082c3ededb4e7fa230)

詳細検索フォームの表示・非表示
[![Image from Gyazo](https://i.gyazo.com/39c64efab26c0b1155d3e5b3f044e61f.gif)](https://gyazo.com/39c64efab26c0b1155d3e5b3f044e61f)

詳細検索
[![Image from Gyazo](https://i.gyazo.com/239073de5a3e341da1f58522208538df.gif)](https://gyazo.com/239073de5a3e341da1f58522208538df)

## 確認方法
1. レシピ一覧ページ`/foods`にアクセスしてフリーワード検索を行い、適当にレシピの詳細ページにアクセスするとレシピ名か材料に検索したワードが含まれていることを確認してください。
2. 詳細検索で複数の条件を指定（材料に卵を含み、たんぱく質が10g以上など）して検索し、レシピの詳細ページで確認してください。（レシピの詳細ページの栄養素の表示はDBの値と違うので分かりにくいかもしれないです。）
3. 詳細検索でタグを指定（複数可）して、そのタグを持つレシピが取得できることを確認してください。
4. レシピ一覧ページの各投稿のタグをクリックするとそのタグを持つレシピを取得できることを確認してください。

## 影響範囲
特になし。

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
タグの検索について
#45 にもあるように、タグの検索は動作してますが無駄なSQLを発行してしまっているのでリファクタリングが必要になりそうです。