### PR TITLE
twitterプロフィール画像が荒い問題対処

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -31,7 +31,7 @@ class OauthsController < ApplicationController
 
   # twitterのプロフィール画像は個別で保存
   def twitter_profile_image(profile_image)
-    @user.remote_avatar_url = profile_image
+    @user.remote_avatar_url = profile_image.gsub(/_normal/, '')
     @user.save!
   end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,7 +4,7 @@
       <div class="text-xl lg:text-3xl lg:text-2xl text-center leading-6 font-medium text-gray-600 font-bold">プロフィール</div>
     </div>
     <div class= "bg-white p-4 lg:p-10 rounded-lg shadow-lg min-w-full">
-      <%= image_tag current_user.avatar.url(:thumb), class: "w-32 h-32 mx-auto shadow-lg rounded-full mb-5" %>
+      <%= image_tag current_user.avatar.url, class: "w-32 h-32 mx-auto shadow-lg rounded-full mb-5" %>
       <div class="text-lg text-center">
         <dl>
           <div class="px-4 py-3 sm:grid sm:grid-cols-2 sm:gap-4 sm:px-6">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 bg-white shadow-xl rounded-2xl">
       <div class="w-full px-4">
         <div class="py-10 mt-10">
-          <%= image_tag @user.avatar.url(:thumb), class: "w-48 h-48 mx-auto shadow-lg rounded-full" %>
+          <%= image_tag @user.avatar.url, class: "w-48 h-48 mx-auto shadow-lg rounded-full" %>
           <h2 class="text-lg lg:text-3xl font-heading font-medium text-center py-7 text-gray-600"><%= @user.name %></h2>
         </div>
       </div>


### PR DESCRIPTION
## 概要
3948f57905b2f5f5542a5fa54bb7b869d6ec7145 twitterプロフィール画像が粗かったので対処しました。

修正前
![スクリーンショット 2022-03-23 8 33 23](https://user-images.githubusercontent.com/74707158/159593273-2692bffc-47eb-4192-a93c-aa63d22e3cba.png)

修正後
![スクリーンショット 2022-03-23 8 31 10](https://user-images.githubusercontent.com/74707158/159593293-adf230ec-2402-48ff-8232-1feef874e692.png)

## 確認方法
1. 一度twitterでログインしたユーザーを削除して、再度ログインしてください
2. マイページ`/profile`にアクセスして、画像が修正前と比べて高画質になっていることを確認してください

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
twitterプロフィール画像が荒くなってしまう問題に対処しました。
