### PR TITLE
栄養素のデータが取得できないときの対処

### DIFF
--- a/app/decorators/nutrition_decorator.rb
+++ b/app/decorators/nutrition_decorator.rb
@@ -1,0 +1,7 @@
+class NutritionDecorator < ApplicationDecorator
+  delegate_all
+
+  def nutrition_check
+    calories.zero?
+  end
+end

--- a/app/form/food_form.rb
+++ b/app/form/food_form.rb
@@ -149,12 +149,16 @@ class FoodForm
     url = URI.parse("https://api.edamam.com/api/nutrition-data?app_id=#{app_id}&app_key=#{app_key}&ingr=#{ingr}")
     response = Net::HTTP.get_response(url)
     response_body = JSON.parse(response.body)
-    {
-      calories: response_body['totalNutrients']['ENERC_KCAL']['quantity'],
-      carbo: response_body['totalNutrients']['CHOCDF']['quantity'],
-      fiber: response_body['totalNutrients']['FIBTG']['quantity'],
-      protein: response_body['totalNutrients']['PROCNT']['quantity'],
-      fat: response_body['totalNutrients']['FAT']['quantity']
-    }
+    if response_body['totalNutrients'].present?
+      {
+        calories: response_body['totalNutrients']['ENERC_KCAL']['quantity'],
+        carbo: response_body['totalNutrients']['CHOCDF']['quantity'],
+        fiber: response_body['totalNutrients']['FIBTG']['quantity'],
+        protein: response_body['totalNutrients']['PROCNT']['quantity'],
+        fat: response_body['totalNutrients']['FAT']['quantity']
+      }
+    else
+      { calories: 0, carbo: 0, fiber: 0, protein: 0, fat: 0 }
+    end
   end
 end

--- a/app/form/food_form.rb
+++ b/app/form/food_form.rb
@@ -118,9 +118,9 @@ class FoodForm
     end
 
     # 翻訳する処理を実行
-    translated_ingredients = google_translation(translate_array)
+    translated_ingredients = google_translation(translate_array) if translate_array.present?
     # 翻訳したデータを使ってマクロ栄養素を算出
-    nutrition_data = nutrition_calculate(translated_ingredients)
+    nutrition_data = translated_ingredients.present? ? nutrition_calculate(translated_ingredients) : { calories: 0, carbo: 0, fiber: 0, protein: 0, fat: 0 }
     # 投稿されたレシピのマクロ栄養素として保存
     food.create_nutrition!(nutrition_data)
   end

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -27,7 +27,7 @@
             <ul class="flex mb-0 list-none flex-wrap flex-row">
               <li class="-mb-px last:mr-0 flex-auto text-center">
                 <a class="text-lg font-bold uppercase px-5 py-2 shadow-lg rounded block leading-normal text-white bg-orange-400" onclick="changeAtiveTab(event,'tab-profile')">
-                  マクロ
+                  マクロ栄養素
                 </a>
               </li>
               <li class="-mb-px last:mr-0 flex-auto text-center">
@@ -40,12 +40,24 @@
               <div class="flex-auto">
                 <div class="tab-content tab-space pt-5">
                   <div class="block" id="tab-profile">
-                    <p class="text-center text-lg font-medium pb-5"><%= @food.name %>のマクロ栄養素(g)</p>
-                    <canvas class="" id="chartRadar" style="display: block; height: 900px; width: 1050px;"></canvas>
+                    <% if @food.nutrition.decorate.nutrition_check %>
+                      <div class="text-center my-20 lg:my-40 py-12 lg:py-24">
+                        <p class="font-bold text-gray-600 text-lg lg:text-2xl px-4 lg:px-0">このレシピの栄養素のデータはありません</p>
+                      </div>
+                    <% else %>
+                      <p class="text-center text-lg font-medium pb-5"><%= @food.name %>のマクロ栄養素(g)</p>
+                      <canvas class="" id="chartRadar" style="display: block; height: 900px; width: 1050px;"></canvas>
+                    <% end %>
                   </div>
                   <div class="hidden" id="tab-settings">
-                    <p class="text-center text-lg font-medium"><%= @food.name %>のカロリー(kcal)と<br>マクロ栄養素のカロリーの割合(%)</p>
-                    <canvas class="p-10" id="chartDoughnut" style="display: block; height: 900px; width: 1050px;"></canvas>
+                    <% if @food.nutrition.decorate.nutrition_check %>
+                      <div class="text-center my-20 lg:my-40 py-12 lg:py-24">
+                        <p class="font-bold text-gray-600 text-lg lg:text-2xl px-4 lg:px-0">このレシピの栄養素のデータはありません</p>
+                      </div>
+                    <% else %>
+                      <p class="text-center text-lg font-medium"><%= @food.name %>のカロリー(kcal)</p>
+                      <canvas class="p-10" id="chartDoughnut" style="display: block; height: 900px; width: 1050px;"></canvas>
+                    <% end %>
                   </div>
                 </div>
               </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -45,7 +45,7 @@
                         <p class="font-bold text-gray-600 text-lg lg:text-2xl px-4 lg:px-0">このレシピの栄養素のデータはありません</p>
                       </div>
                     <% else %>
-                      <p class="text-center text-lg font-medium pb-5"><%= @food.name %>のマクロ栄養素(g)</p>
+                      <p class="text-center text-lg font-medium pb-5"><%= @food.name %>のマクロ栄養素(g)<br>（１食当たり）</p>
                       <canvas class="" id="chartRadar" style="display: block; height: 900px; width: 1050px;"></canvas>
                     <% end %>
                   </div>
@@ -55,7 +55,7 @@
                         <p class="font-bold text-gray-600 text-lg lg:text-2xl px-4 lg:px-0">このレシピの栄養素のデータはありません</p>
                       </div>
                     <% else %>
-                      <p class="text-center text-lg font-medium"><%= @food.name %>のカロリー(kcal)</p>
+                      <p class="text-center text-lg font-medium"><%= @food.name %>のカロリー(kcal)<br>（１食当たり）</p>
                       <canvas class="p-10" id="chartDoughnut" style="display: block; height: 900px; width: 1050px;"></canvas>
                     <% end %>
                   </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -41,7 +41,7 @@
                 <div class="tab-content tab-space pt-5">
                   <div class="block" id="tab-profile">
                     <% if @food.nutrition.decorate.nutrition_check %>
-                      <div class="text-center my-20 lg:my-40 py-12 lg:py-24">
+                      <div class="text-center my-20 lg:my-24 2xl:my-40 py-12 lg:py-24 2xl:py-24">
                         <p class="font-bold text-gray-600 text-lg lg:text-2xl px-4 lg:px-0">このレシピの栄養素のデータはありません</p>
                       </div>
                     <% else %>


### PR DESCRIPTION
## 概要
776218f2a3d7a06b80401fb47fc5b890d5aeae75 すべての材料の量が`適量`だった場合、翻訳APIと栄養素取得APIを叩かないようにしました。
7169157f76300d4d63aede96a25fb2d0f6d54e0a 栄養素取得のAPIを叩いてデータが取得できていなかった場合に対処しました。
14c1427d4fa383d4310cb3b7555e635a7e620824 栄養素のデータが取得できていなかった場合、レシピの詳細ページで表示を切り替えるようにしました。

レシピ詳細ページ
<img width="722" alt="スクリーンショット 2022-03-24 11 43 11" src="https://user-images.githubusercontent.com/74707158/159831665-91f35d1d-362f-40d4-b20a-f8d123e8bad5.png">

## 確認方法
1. レシピ新規投稿ページ`/foods/new`にアクセスし、各フォームを入力し投稿してください。その際に、材料の量はすべて`適量`を選択して投稿し、投稿が成功することを確認してください。
2. そのレシピの詳細ページ`/foods/:uuid`にアクセスし、栄養素のグラフの箇所に「`このレシピの栄養素のデータはありません`」と表示されていることを確認してください。
3. レシピ新規投稿ページ`/foods/new`にアクセスし、各フォームを入力し投稿してください。その際に、材料で材料名に「`お茶漬け`」、量に「`1袋`」と入力して投稿し、投稿が成功することを確認してください。
4.  そのレシピの詳細ページ`/foods/:uuid`にアクセスし、栄養素のグラフの箇所に「`このレシピの栄養素のデータはありません`」と表示されていることを確認してください。

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
レシピ投稿時の栄養素のデータが取得できないバグを対処しました。
根本的な解決にはなっていませんが、エラーは出なくなったと思います。
すべての材料の量が適量だった場合は、データを取得できないことがわかっているので、そもそもAPIを叩かないようにしました。
また、APIを叩いてデータが取得できていなかった場合は、代わりに`0`を保存するようにしました。
一旦、エラーが出なくなったのでこのまま進めます。
