### PR TITLE
グラフのフォントをレスポンシブ対応

### DIFF
--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -147,6 +147,14 @@
 
 <!-- Chart radar -->
 <script>
+  if (window.matchMedia( "(min-width: 1024px)" ).matches) {
+    var fontSize = 20;
+  } else if (window.matchMedia( "(min-width: 768px)" ).matches) {
+    var fontSize = 15;
+  } else {
+    var fontSize = 10;
+  }
+
   const dataRadar = {
     labels: [
       "炭水化物",
@@ -179,11 +187,11 @@
         ticks: {
           suggestedMin: 0,
           stepSize: 5,
-          fontSize: 20,
+          fontSize: fontSize,
           fontColor: '#000'
         },
         pointLabels: {
-          fontSize: 20,
+          fontSize: fontSize,
           fontColor: '#000'
         }
       },
@@ -201,6 +209,16 @@
 
 <!-- Chart doughnut -->
 <script>
+if (window.matchMedia( "(min-width: 768px)" ).matches) {
+    var macrolabel = 25;
+    var totallabel = 60;
+    var calorielabel = 45;
+  } else {
+    var macrolabel = 15;
+    var totallabel = 40;
+    var calorielabel = 35;
+  }
+
   const dataDoughnut = {
     labels: [
       "炭水化物",
@@ -239,7 +257,7 @@
             render: function (args) {
               return args.label + '\n' + args.value + '%';
             },
-            fontSize: 25,
+            fontSize: macrolabel,
             fontColor: '#fff',
           }
         ],
@@ -248,7 +266,7 @@
             {
               text: '合計',
               font: {
-                size: '60',
+                size: totallabel,
                 tyle: 'italic',
                 wieght: 'bold'
               }
@@ -256,7 +274,7 @@
             {
               text: gon.nutrition_calories[3] + 'kcal',
               font: {
-                size: '45'
+                size: calorielabel
               },
             color: 'red'
             }


### PR DESCRIPTION
## 概要
189b5dd620557f8e633ca682ce8c358e2b1a33be グラフのフォントをレスポンシブ対応させました。

PCのレーダーチャート
<img width="500" alt="スクリーンショット 2022-03-26 8 05 15" src="https://user-images.githubusercontent.com/74707158/160213038-fe8b3b16-b29f-461b-a6a4-73dddb06c12b.png">

スマホのレーダーチャート
<img width="500" alt="スクリーンショット 2022-03-26 8 05 52" src="https://user-images.githubusercontent.com/74707158/160213090-9df6b184-aa94-44b2-9849-cf80521be1d3.png">

PCのドーナツグラフ
<img width="500" alt="スクリーンショット 2022-03-26 8 05 31" src="https://user-images.githubusercontent.com/74707158/160213043-6ab0c22d-bd6f-4575-a13a-6062de5819e7.png">

スマホのドーナツグラフ
<img width="500" alt="スクリーンショット 2022-03-26 8 05 59" src="https://user-images.githubusercontent.com/74707158/160213101-6adf09b0-80c5-4446-bfca-2e264646186a.png">

## 確認方法
1. 適当なレシピ詳細ページ`/foods/:uuid`にアクセスし、検証ツールを使ってPC・タブレット・スマホの場合でマクロ栄養素とカロリーのグラフをそれぞれ表示させ、ラベルがグラフに収まっていることを確認してください。
2. 検証ツールで端末を切り替える度にブラウザをリロードしてください。

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
chart.jsのフォントをレスポンシブ対応させました。
これで決定ではないですが、フォントサイズを変えることはできるのでこのまま進めます。
